### PR TITLE
feat: add Spinner component for loading indication in Suspense fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { routes } from "./routes/route";
 import Header from "./layouts/Header";
 import Footer from "./layouts/Footer";
+import { Spinner } from "./components/ui/spinner";
 
 // Layout component to wrap pages with consistent structure
 const Layout = ({ children }: { children: React.ReactNode }) => {
@@ -21,7 +22,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 const App = () => {
   return (
     <Router>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<Spinner />}>
         <Routes>
           {routes.map(({ path, component: Component }, index) => (
             <Route

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,23 @@
+import { LoaderIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <LoaderIcon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-8 animate-spin", className)}
+      {...props}
+    />
+  );
+}
+
+export function SpinnerCustom() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-white/80">
+      <Spinner />
+    </div>
+  );
+}
+
+export { SpinnerCustom as Spinner };


### PR DESCRIPTION
This pull request updates the application's loading experience by introducing a reusable spinner component and replacing the previous loading indicator with it. The main change is the addition of a custom spinner using the `lucide-react` icon set, which ensures a more consistent and visually appealing loading state across the app.

**UI Improvements:**

* Added a new `Spinner` component in `src/components/ui/spinner.tsx` that uses the `LoaderIcon` from `lucide-react` and includes accessibility attributes for better user experience.
* The fallback loading indicator in the `Suspense` component within `src/App.tsx` has been updated to use the new `Spinner` component instead of a plain "Loading..." text.

**Refactoring and Imports:**

* Imported the new `Spinner` component in `src/App.tsx` to enable its use as the Suspense fallback.