### PR TITLE
feat: update Header component styling and improve layout consistency

### DIFF
--- a/src/layouts/Footer.tsx
+++ b/src/layouts/Footer.tsx
@@ -59,6 +59,13 @@ function Footer() {
           </Form>
         </div>
       </div>
+      <hr className=" border-white/20 mx-auto" />
+      <p className="text-center text-sm text-white/80">
+        <small>
+          &copy; {new Date().getFullYear()} Marcelino's Place | All Rights
+          Reserved.
+        </small>
+      </p>
     </footer>
   );
 }

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -26,19 +26,21 @@ export default function Header() {
     <header className="sticky top-0 z-50 w-full border-b bg-white shadow-sm">
       <div className="max-w-7xl mx-auto flex h-20 items-center justify-between px-4 md:px-8">
         {/* --- Logo --- */}
-        <a href="/" className="flex items-center gap-2">
+        <a href="/" className="flex items-center">
           <img
             src="/logo.webp"
             alt="Marcelino’s Logo"
             className="w-10 h-10 object-contain"
           />
-          <span className="text-2xl font-bold text-black">Marcelino’s</span>
+          <span className="text-2xl font-extrabold text-black">
+            Marcelino’s
+          </span>
         </a>
 
         {/* --- Desktop Navigation --- */}
         <nav className="hidden md:flex items-center gap-8">
           <NavigationMenu>
-            <NavigationMenuList className="flex items-center gap-6">
+            <NavigationMenuList className="flex items-center gap-4">
               {navLinks.map((item) => (
                 <NavigationMenuItem key={item.href}>
                   <NavigationMenuLink asChild>


### PR DESCRIPTION
This pull request makes minor visual improvements to the site's header and footer. The header's logo text is now bolder, and the navigation spacing is slightly reduced. The footer now includes a horizontal rule and a copyright notice.

Header visual adjustments:

* Increased the font weight of the logo text in the header to `font-extrabold` and removed extra gap between logo and text.
* Reduced the spacing between navigation menu items in the header.

Footer enhancements:

* Added a horizontal rule and a centered copyright notice with the current year to the footer.