### PR TITLE
fix: remove unnecessary line break in Footer component title

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,7 +25,7 @@ function Footer() {
         {/* ---------------------------------- */}
         <section className="col-span-3 md:col-span-1">
           <h3 className="yellow md:text-lg font-bold">
-            Marcelino's Resort <br /> Hotel
+            Marcelino's Resort Hotel
           </h3>
           <p>
             Experience luxury and comfort at its finest. Subscribe to our


### PR DESCRIPTION
This pull request includes a minor text change to the `Footer` component, correcting the formatting of the resort's name by removing an unnecessary line break.