### PR TITLE
fix: clean up formatting in README for FormWrapper component

### DIFF
--- a/src/components/forms/README.md
+++ b/src/components/forms/README.md
@@ -3,7 +3,7 @@
 A lightweight, reusable form generator built with React Hook Form, Zod, and shadcn/ui.
 It allows developers to quickly scaffold and validate forms without repetitive boilerplate.
 
----
+-
 
 ⚙️ Features
 
@@ -17,7 +17,7 @@ It allows developers to quickly scaffold and validate forms without repetitive b
 
 🧾 Handles both Input and Textarea automatically
 
----
+-
 
 📦 File Structure
 
@@ -33,7 +33,7 @@ src/
     └── ContactForm.tsx      # Example usage
 ```
 
----
+-
 
 🚀 Getting Started
 
@@ -56,9 +56,7 @@ const contactSchema = z.object({
 
 > 💡 **Pro tip:** Always type your schema values with `z.infer<typeof schema>` to ensure form consistency.
 
----
-
-**3. Define Your Fields**
+- **3. Define Your Fields**
 
 Each field in the form is represented by a simple config object.
 
@@ -79,10 +77,8 @@ const fields = [
 | `placeholder?` | `string`                                                    | Input placeholder                   |
 | `type?`        | `"text" \| "number" \| "email" \| "password" \| "textarea"` | Defaults to `"text"`                |
 
----
-
-**4. Handle Submission**
-Define your submit handler. It receives strongly typed form data.
+- **4. Handle Submission**
+  Define your submit handler. It receives strongly typed form data.
 
 ```tsx
 const handleSubmit = (values: z.infer<typeof contactSchema>) => {
@@ -90,9 +86,7 @@ const handleSubmit = (values: z.infer<typeof contactSchema>) => {
 };
 ```
 
----
-
-**5. Use the Wrapper**
+- **5. Use the Wrapper**
 
 Finally, render your form using the wrapper component.
 
@@ -105,7 +99,7 @@ Finally, render your form using the wrapper component.
 />
 ```
 
----
+-
 
 🧰 **Props Reference**
 | Prop | Type | Required | Description |
@@ -116,7 +110,7 @@ Finally, render your form using the wrapper component.
 | `submitLabel` | `string` | ❌ | Custom submit button label |
 | `buttons` | `React.ReactNode[]` | ❌ | Optional extra buttons (e.g., cancel) |
 
----
+-
 
 🧪 **Example — Contact Form**
 
@@ -154,7 +148,7 @@ export default function ContactForm() {
 }
 ```
 
----
+-
 
 🧠 **Notes & Best Practices**
 
@@ -166,7 +160,7 @@ Prefer composable, small schemas (can be reused across forms).
 
 Add new field types (like select, checkbox, etc.) directly inside FormWrapper.
 
----
+-
 
 💡 **Extending It**
 


### PR DESCRIPTION
This pull request updates the `src/components/forms/README.md` file to improve formatting and consistency throughout the documentation. The changes mainly involve minor markdown adjustments, such as adding or correcting dashes and spacing, to enhance readability and structure.

Documentation formatting improvements:

* Standardized section breaks and headers throughout the README by adding or correcting dashes and spacing, making the guide easier to follow. [[1]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L6-R6) [[2]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L20-R20) [[3]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L36-R36) [[4]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L108-R102) [[5]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L119-R113) [[6]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L157-R151) [[7]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L169-R163)
* Improved the step-by-step instructions by updating the formatting of steps 3–5 to use a consistent dash style for better clarity. [[1]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L59-R59) [[2]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L82-R80) [[3]](diffhunk://#diff-d6cba0c63e6b75cff392683c71441a07705b1d5a28384b145d9d0c2a4779b557L93-R89)