### PR TITLE
feat: refactor WritingText component to use forwardRef for improved r…

### DIFF
--- a/src/components/ui/shadcn-io/writing-text/index.tsx
+++ b/src/components/ui/shadcn-io/writing-text/index.tsx
@@ -1,62 +1,67 @@
-'use client';
- 
-import * as React from 'react';
+import * as React from "react";
 import {
   motion,
   useInView,
   type Transition,
   type UseInViewOptions,
-} from 'motion/react';
- 
-type WritingTextProps = Omit<React.ComponentProps<'span'>, 'children'> & {
+} from "motion/react";
+
+type WritingTextProps = Omit<React.ComponentProps<"span">, "children"> & {
   transition?: Transition;
   inView?: boolean;
-  inViewMargin?: UseInViewOptions['margin'];
+  inViewMargin?: UseInViewOptions["margin"];
   inViewOnce?: boolean;
   spacing?: number | string;
   text: string;
 };
- 
-function WritingText({
-  ref,
-  inView = false,
-  inViewMargin = '0px',
-  inViewOnce = true,
-  spacing = 5,
-  text,
-  transition = { type: 'spring', bounce: 0, duration: 2, delay: 0.5 },
-  ...props
-}: WritingTextProps) {
-  const localRef = React.useRef<HTMLSpanElement>(null);
-  React.useImperativeHandle(ref, () => localRef.current as HTMLSpanElement);
- 
-  const inViewResult = useInView(localRef, {
-    once: inViewOnce,
-    margin: inViewMargin,
-  });
-  const isInView = !inView || inViewResult;
- 
-  const words = React.useMemo(() => text.split(' '), [text]);
- 
-  return (
-    <span ref={localRef} data-slot="writing-text" {...props}>
-      {words.map((word, index) => (
-        <motion.span
-          key={index}
-          className="inline-block will-change-transform will-change-opacity"
-          style={{ marginRight: spacing }}
-          initial={{ opacity: 0, y: 10 }}
-          animate={isInView ? { opacity: 1, y: 0 } : undefined}
-          transition={{
-            ...transition,
-            delay: index * (transition?.delay ?? 0),
-          }}
-        >
-          {word}{' '}
-        </motion.span>
-      ))}
-    </span>
-  );
-}
- 
+
+// ✅ Proper ref forwarding with generics
+const WritingText = React.forwardRef<HTMLSpanElement, WritingTextProps>(
+  (
+    {
+      inView = false,
+      inViewMargin = "0px",
+      inViewOnce = true,
+      spacing = 5,
+      text,
+      transition = { type: "spring", bounce: 0, duration: 2, delay: 0.5 },
+      ...props
+    },
+    ref
+  ) => {
+    const localRef = React.useRef<HTMLSpanElement>(null);
+    React.useImperativeHandle(ref, () => localRef.current as HTMLSpanElement);
+
+    const inViewResult = useInView(localRef, {
+      once: inViewOnce,
+      margin: inViewMargin,
+    });
+    const isInView = !inView || inViewResult;
+
+    const words = React.useMemo(() => text.split(" "), [text]);
+
+    return (
+      <span ref={localRef} data-slot="writing-text" {...props}>
+        {words.map((word, index) => (
+          <motion.span
+            key={index}
+            className="inline-block will-change-transform will-change-opacity"
+            style={{ marginRight: spacing }}
+            initial={{ opacity: 0, y: 10 }}
+            animate={isInView ? { opacity: 1, y: 0 } : undefined}
+            transition={{
+              ...transition,
+              delay: index * (transition?.delay ?? 0),
+            }}>
+            {word}{" "}
+          </motion.span>
+        ))}
+      </span>
+    );
+  }
+);
+
+// ✅ Give it a display name (helps React DevTools)
+WritingText.displayName = "WritingText";
+
 export { WritingText, type WritingTextProps };


### PR DESCRIPTION
This pull request refactors the `WritingText` component in `src/components/ui/shadcn-io/writing-text/index.tsx` to improve React best practices and code clarity. The main changes include converting the component to use `React.forwardRef` with proper generics, updating code style for consistency, and assigning a display name for better debugging.

**Component refactor and best practices:**

* Refactored `WritingText` to use `React.forwardRef<HTMLSpanElement, WritingTextProps>`, enabling proper ref forwarding and improved type safety.
* Added `WritingText.displayName = "WritingText"` to enhance debugging in React DevTools.

**Code style and consistency:**

* Switched all string quotes to double quotes for consistency and updated object property access accordingly. [[1]](diffhunk://#diff-344143b46ca451aaf9d869764e784c88e7f91f23a32db7ec151864ed8a4dc349L1-R31) [[2]](diffhunk://#diff-344143b46ca451aaf9d869764e784c88e7f91f23a32db7ec151864ed8a4dc349L39-R41) [[3]](diffhunk://#diff-344143b46ca451aaf9d869764e784c88e7f91f23a32db7ec151864ed8a4dc349L53-R65)
* Minor code formatting improvements, such as using `{" "}` for spaces between words. [[1]](diffhunk://#diff-344143b46ca451aaf9d869764e784c88e7f91f23a32db7ec151864ed8a4dc349L39-R41) [[2]](diffhunk://#diff-344143b46ca451aaf9d869764e784c88e7f91f23a32db7ec151864ed8a4dc349L53-R65)…ef handling