### PR TITLE
fix: uncomment plugin usage in BannerCarousel for proper functionality

### DIFF
--- a/src/components/carousels/BannerCarousel.tsx
+++ b/src/components/carousels/BannerCarousel.tsx
@@ -17,7 +17,7 @@ import image1 from "@/assets/img/banner-1.webp";
 export function BannerCarousel() {
   const [api, setApi] = useState<CarouselApi | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
-  // const plugin = useRef(Autoplay({ delay: 4000 }));
+  const plugin = useRef(Autoplay({ delay: 4000 }));
 
   useEffect(() => {
     if (!api) return;
@@ -40,7 +40,7 @@ export function BannerCarousel() {
   return (
     <Carousel
       opts={{ align: "start", loop: true }}
-      // plugins={[plugin.current]}
+      plugins={[plugin.current]}
       setApi={setApi}>
       <CarouselContent className="ml-0 gap-0 [&>*]:pl-0 [&>*]:mr-0">
         {Array.from({ length: 5 }).map((_, index) => {


### PR DESCRIPTION
This pull request re-enables the autoplay functionality in the `BannerCarousel` component by uncommenting the relevant lines. The carousel will now automatically advance slides every 4 seconds.

Carousel autoplay re-enabled:

* Uncommented the initialization of the `Autoplay` plugin with a 4000ms delay in `BannerCarousel.tsx`.
* Passed the `Autoplay` plugin to the `Carousel` component's `plugins` prop to activate autoplay.