### PR TITLE
fix: restore NotFound route in routes configuration and add vercel.js…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,6 @@ const App = () => {
               }
             />
           ))}
-          <Route path="*" element={<NotFound />} />
         </Routes>
       </Suspense>
     </Router>

--- a/src/routes/route.ts
+++ b/src/routes/route.ts
@@ -3,11 +3,10 @@ import { lazy } from "react";
 
 const Home = lazy(() => import("../pages/Home"));
 const About = lazy(() => import("../pages/About"));
+const NotFound = lazy(() => import("../pages/NotFound"));
 
 export const routes = [
   { path: "/", component: Home },
   { path: "/about", component: About },
-  //   { path: "*", component: NotFound },
-
-  // Developer individual pages
+  { path: "*", component: NotFound },
 ];

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
This pull request updates the application's routing to improve handling of unknown routes and ensures proper client-side routing support for deployments (such as on Vercel). The main changes involve moving the "NotFound" route definition into a centralized route configuration and adding a rewrite rule for client-side routing.

Routing improvements:

* Added a `NotFound` component to the `routes` array in `src/routes/route.ts`, ensuring that any unmatched route renders the `NotFound` page.
* Removed the direct `<Route path="*">` definition from `src/App.tsx` to rely on the centralized route configuration.

Deployment configuration:

* Added a `vercel.json` file with a rewrite rule to route all requests through `index.html`, enabling proper client-side routing support on Vercel.…on for deployment