### PR TITLE
fix: remove unused NotFound import from App component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { routes } from "./routes/route";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import NotFound from "./pages/NotFound";
 import { Spinner } from "./components/ui/spinner";
 
 // Layout component to wrap pages with consistent structure


### PR DESCRIPTION
This pull request makes a small change by removing the import of the unused `NotFound` component from the `src/App.tsx` file. This helps keep the codebase clean and free of unnecessary imports.