### PR TITLE
refactor(apiClient): comment out request interceptor for token attach…

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -21,13 +21,13 @@ const apiClient: AxiosInstance = axios.create({
 });
 
 // Interceptor: Automatically attach token if exists
-apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
+// apiClient.interceptors.request.use((config) => {
+//   const token = localStorage.getItem("token");
+//   if (token) {
+//     config.headers.Authorization = `Bearer ${token}`;
+//   }
+//   return config;
+// });
 
 // Response Interceptor: Error normalization
 apiClient.interceptors.response.use(


### PR DESCRIPTION
This pull request makes a small change by commenting out the request interceptor in `src/lib/apiClient.ts` that was automatically attaching an authorization token to outgoing requests. No other changes are included.

- Commented out the request interceptor that added the `Authorization` header with a bearer token from local storage in `apiClient`.…ment