### PR TITLE
MWA-86: feat: enhance mobile menu accessibility with DialogTitle and …

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/navigation-menu";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
+import { DialogTitle } from "@radix-ui/react-dialog";
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -70,15 +71,28 @@ export default function Header() {
               <Menu className="h-6 w-6" />
             </Button>
           </SheetTrigger>
-          <SheetContent side="top" className="bg-white">
-            <nav className="flex flex-wrap justify-content-center items-center gap-5 md:mt-10 p-5">
+          <SheetContent
+            side="top"
+            aria-describedby="mobile-menu-title"
+            className="bg-white">
+            {/* Add DialogTitle for accessibility */}
+
+            <DialogTitle className="text-center text-2xl font-extrabold p-4 border-b">
+              Marcelino’s
+            </DialogTitle>
+            <div className="sr-only" id="mobile-menu-title">
+              Mobile Navigation Menu
+            </div>
+            <nav
+              aria-labelledby="mobile-menu-title"
+              className="flex flex-col justify-center items-center gap-3 md:mt-10 p-5">
               {navLinks.map((item) => (
                 <a
                   key={item.href}
                   href={item.href}
                   onClick={() => setOpen(false)}
                   className="text-lg font-medium text-black hover:text-yellow-600">
-                  {item.label}
+                  <span>{item.label}</span>
                 </a>
               ))}
               <Button className="bg-yellow-400 hover:bg-yellow-500 text-white font-semibold rounded-lg">


### PR DESCRIPTION
This pull request improves the accessibility and structure of the mobile navigation menu in the `Header` component. The main changes focus on making the mobile menu more accessible to screen readers and visually enhancing the menu's title.

Accessibility and UI improvements:

* Added `DialogTitle` from `@radix-ui/react-dialog` to the mobile menu for a clear, accessible menu heading. [[1]](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fR11) [[2]](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL73-R95)
* Introduced a visually hidden (`sr-only`) element with an `id` for screen readers and updated the `nav` element to use `aria-labelledby` for better accessibility.
* Changed the navigation menu layout from a flex row to a flex column for improved mobile presentation.…aria attributes