### PR TITLE
MWA-106: Fix gender placeholder and validation in multi-step form

### DIFF
--- a/src/lib/validators/personalDetails.schema.ts
+++ b/src/lib/validators/personalDetails.schema.ts
@@ -16,8 +16,10 @@ export const personalDetailsSchema = z.object({
   lastName: z.string().min(1, "Last name is required").transform(toTitleCase),
 
   gender: z
-    .enum(["Male", "Female"])
-    .refine((v) => v !== undefined, "Gender is required"),
+    .string()
+    .refine((v) => v === "Male" || v === "Female", {
+      message: "Please select a gender",
+    }),
 
   phone: z
     .string()

--- a/src/pages/Booking/Multi-Step-Form.tsx
+++ b/src/pages/Booking/Multi-Step-Form.tsx
@@ -38,7 +38,7 @@ const STEPS = [
   { id: 5, icon: <PartyPopper className="h-5 w-5 md:h-8 md:w-8" /> },
 ];
 
-export type Gender = "Male" | "Female";
+export type Gender = string;
 
 export interface FormData {
   current_step: number;
@@ -50,7 +50,7 @@ export interface FormData {
   firstName: string;
   middleName: string | null;
   lastName: string;
-  gender: Gender;
+  gender: string;
   phone: string;
   email: string;
   address: string;
@@ -81,7 +81,7 @@ const defaultFormData: FormData = {
   firstName: "",
   middleName: null,
   lastName: "",
-  gender: "Male", // 👈 REQUIRED
+  gender: "", 
   phone: "",
   email: "",
   address: "",


### PR DESCRIPTION
This pull request updates how gender is handled in the personal details form, making the validation more flexible and improving error messaging. The main changes involve switching from a strict enum type to a string type for gender and updating validation logic accordingly.

**Form validation and typing updates:**

* Changed the `gender` field in `personalDetailsSchema` from a Zod enum to a string, with a custom refinement to only allow "Male" or "Female" and a clearer error message ("Please select a gender").
* Updated the `Gender` type and the `gender` property in the `FormData` interface from a union type (`"Male" | "Female"`) to a plain `string`, reflecting the new validation approach. [[1]](diffhunk://#diff-11280bbf10a040475df24d2bc45504bd7c86c7d0c27b2de46ba156381b9d98faL41-R41) [[2]](diffhunk://#diff-11280bbf10a040475df24d2bc45504bd7c86c7d0c27b2de46ba156381b9d98faL53-R53)
* Changed the default value of `gender` in `defaultFormData` from `"Male"` to an empty string, ensuring users must actively select a gender.