### PR TITLE
chore: add @types/dom-to-image dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@types/dom-to-image": "^2.6.7",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^24.7.0",
         "@types/react": "^18.3.3",
@@ -2476,6 +2477,13 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/dom-to-image": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@types/dom-to-image/-/dom-to-image-2.6.7.tgz",
+      "integrity": "sha512-me5VbCv+fcXozblWwG13krNBvuEOm6kA5xoa4RrjDJCNFOZSWR3/QLtOXimBHk1Fisq69Gx3JtOoXtg1N1tijg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@types/dom-to-image": "^2.6.7",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^24.7.0",
     "@types/react": "^18.3.3",


### PR DESCRIPTION
This pull request makes a minor update to the project's development dependencies by adding type definitions for the `dom-to-image` library to `package.json`. This will improve TypeScript support when working with `dom-to-image` in development.