### PR TITLE
refactor: update image imports in ImageCarousel component

### DIFF
--- a/src/pages/Home/OurGallery.tsx
+++ b/src/pages/Home/OurGallery.tsx
@@ -4,14 +4,13 @@ import { Pagination, Autoplay } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/pagination";
 import "swiper/css/autoplay";
+import slide1 from "@/assets/img/slide1.webp";
+import slide2 from "@/assets/img/slide2.webp";
+import slide3 from "@/assets/img/slide3.webp";
+import slide4 from "@/assets/img/slide4.webp";
 
 const ImageCarousel: React.FC = () => {
-  const images: string[] = [
-    "/src/assets/img/slide1.webp",
-    "/src/assets/img/slide2.webp",
-    "/src/assets/img/slide3.webp",
-    "/src/assets/img/slide4.webp",
-  ];
+  const images: string[] = [slide1, slide2, slide3, slide4];
 
   return (
     <section


### PR DESCRIPTION
This pull request updates the way images are imported and referenced in the `ImageCarousel` component of `OurGallery.tsx`. Instead of using string paths, images are now imported as modules, which improves reliability and compatibility with build tools.

**Image import and usage improvements:**

* Changed image references in `ImageCarousel` from string paths to imported image modules, updating the `images` array to use these imports (`slide1`, `slide2`, etc.) instead of hardcoded strings.