### PR TITLE
fix: use saveToLocalStorage with expiration for reservationDate

### DIFF
--- a/src/components/forms/BookingForm.tsx
+++ b/src/components/forms/BookingForm.tsx
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { FormWrapper } from "./FormWrapper";
 import { useNavigate } from "react-router-dom";
+import { BOOKING_EXPIRATION, saveToLocalStorage} from "@/lib/storage/localStorage";
 
 const bookingSchema = z.object({
   days: z.coerce.number().min(1, "Invalid number of days"),
@@ -41,10 +42,17 @@ export default function BookingForm() {
     },
   ];
 
-  const handleSubmit = (values: z.infer<typeof bookingSchema>) => {
-    localStorage.setItem("reservationDate", JSON.stringify(values));
-    navigate("/create-booking");
-  };
+const handleSubmit = (values: z.infer<typeof bookingSchema>) => {
+
+  saveToLocalStorage(
+    "reservationDate",
+    values,
+    BOOKING_EXPIRATION
+  );
+
+  navigate("/create-booking");
+
+};
 
   return (
     <div>

--- a/src/components/modals/WelcomeModal.tsx
+++ b/src/components/modals/WelcomeModal.tsx
@@ -6,6 +6,7 @@ import {
   getFromLocalStorage,
 } from "@/lib/storage/localStorage";
 
+const STORAGE_EXPIRATION_MS =  0; 
 const STORAGE_KEY = "marcelino_modal_accepted";
 
 function getAlreadyAccepted(): boolean {
@@ -17,7 +18,7 @@ export default function WelcomeModal() {
   const [open, setOpen] = useState(() => !getAlreadyAccepted());
 
   const handleAccept = () => {
-    saveToLocalStorage(STORAGE_KEY, "true");
+    saveToLocalStorage(STORAGE_KEY, "true", STORAGE_EXPIRATION_MS);
     setOpen(false);
   };
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -71,7 +71,7 @@ function SheetContent({
       >
         {children}
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
+          <XIcon className="size-7" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>

--- a/src/hooks/useBookingForm.ts
+++ b/src/hooks/useBookingForm.ts
@@ -6,9 +6,9 @@ import { formatDate } from "@/lib/formatters/formatDate";
 import {
   saveToLocalStorage,
   getFromLocalStorage,
+  BOOKING_EXPIRATION,
 } from "@/lib/storage/localStorage";
 import { calculateTotalPrice, calculateGrandTotalPrice } from "@/lib/math/calculate";
-
 /**
  * Custom hook for managing booking form state and persistence
  */
@@ -38,7 +38,7 @@ export const useBookingForm = () => {
 
   // Keep localStorage synced with formData
   useEffect(() => {
-    saveToLocalStorage("reservationDetails", formData);
+    saveToLocalStorage("reservationDetails", formData, BOOKING_EXPIRATION);
   }, [formData]);
 
   // Autoload from localStorage when mounted (in case user refreshes)
@@ -49,11 +49,10 @@ export const useBookingForm = () => {
 
   // Redirect if no reservation date
   useEffect(() => {
-    if (!reservationDate?.check_in) {
+    if (!reservationDate || reservationDate.days === 0) {
       navigate("/");
     }
   }, [reservationDate, navigate]);
-
   // Keep grandTotalPrice in sync when days or rooms/venues change
   useEffect(() => {
     setFormData((prev) => ({

--- a/src/lib/storage/localStorage.ts
+++ b/src/lib/storage/localStorage.ts
@@ -4,8 +4,25 @@
  * @param {any} value - The value to be stored in local storage.
  * @returns None
  */
-export const saveToLocalStorage = (key: string, value: any) => {
-  localStorage.setItem(key, JSON.stringify(value));
+
+// default and recommended expiration for booking-related data (e.g. reservation details) 
+// 30 minutes after last update
+
+export const BOOKING_EXPIRATION = 30 * 60 * 1000;
+
+export const saveToLocalStorage = (
+  key: string,
+  value: any,
+  expirationInMs?: number
+): void => {
+  const item = {
+    value,
+    expiry: expirationInMs
+      ? Date.now() + expirationInMs
+      : null,
+  };
+
+  localStorage.setItem(key, JSON.stringify(item));
 };
 
 /**
@@ -14,9 +31,42 @@ export const saveToLocalStorage = (key: string, value: any) => {
  * @returns The value associated with the key if found, otherwise null.
  */
 export const getFromLocalStorage = (key: string) => {
-  const item = localStorage.getItem(key);
-  return item ? JSON.parse(item) : null;
+
+  const itemStr = localStorage.getItem(key);
+
+  if (!itemStr) return null;
+
+  try {
+
+    const item = JSON.parse(itemStr);
+
+    if (!item.expiry) {
+
+      return item.value;
+
+    }
+
+    if (Date.now() > item.expiry) {
+
+      localStorage.removeItem(key);
+
+      return null;
+
+    }
+
+    return item.value;
+
+  } catch {
+
+    localStorage.removeItem(key);
+
+    return null;
+
+  }
+
 };
+
+
 
 /** Keys used for booking flow */
 const BOOKING_KEYS = [


### PR DESCRIPTION
- Replace direct localStorage.setItem with saveToLocalStorage to include expiration.
- Ensures reservationDate follows the { value, expiry } structure.
- Prevents invalid data from breaking booking flow and redirects.
- Keeps frontend expiration consistent with booking form logic.