### PR TITLE
feat: Add react-toastify dependency for toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-leaflet": "^4.2.1",
         "react-modal": "^3.16.3",
         "react-router-dom": "^7.9.3",
+        "react-toastify": "^11.0.5",
         "sweetalert2": "^11.26.3",
         "sweetalert2-react-content": "^5.1.0",
         "swiper": "^12.0.2",
@@ -5036,6 +5037,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-leaflet": "^4.2.1",
     "react-modal": "^3.16.3",
     "react-router-dom": "^7.9.3",
+    "react-toastify": "^11.0.5",
     "sweetalert2": "^11.26.3",
     "sweetalert2-react-content": "^5.1.0",
     "swiper": "^12.0.2",


### PR DESCRIPTION
This pull request adds a new dependency to the project. The most important change is the inclusion of `react-toastify` in the `package.json` file, which will enable toast notifications in the application.

New dependency:

* Added `react-toastify` version `^11.0.5` to `package.json` to support toast notifications.- Included react-toastify version 11.0.5 in package.json and package-lock.json to enable toast notifications in the application.