### PR TITLE
Refactor CardItem and RoomCard to remove bed_modifiers for cleaner code

### DIFF
--- a/src/components/cards/CardItem.tsx
+++ b/src/components/cards/CardItem.tsx
@@ -18,7 +18,6 @@ interface CardItemProps {
   onClick?: () => void;
 
   bed_specifications?: string[];
-  bed_modifiers?: string[];
 }
 
 function CardItem(props: CardItemProps) {
@@ -32,7 +31,6 @@ function CardItem(props: CardItemProps) {
     featured_image,
     gallery = [],
     bed_specifications,
-    bed_modifiers,
     images: imagesProp,
     onClick,
   } = props;
@@ -131,9 +129,6 @@ function CardItem(props: CardItemProps) {
                 <span className="font-medium text-green-800">Beds:</span>
                 <span>
                   {bed_specifications.join(", ")}
-                  {bed_modifiers &&
-                    bed_modifiers.length > 0 &&
-                    ` (${bed_modifiers.join(", ")})`}
                 </span>
               </li>
             )}
@@ -202,9 +197,6 @@ function CardItem(props: CardItemProps) {
                   {bed_specifications && bed_specifications.length > 0 && (
                     <p>
                       Beds: {bed_specifications.join(", ")}
-                      {bed_modifiers &&
-                        bed_modifiers.length > 0 &&
-                        ` (${bed_modifiers.join(", ")})`}
                     </p>
                   )}
                 </div>

--- a/src/lib/formatters/roomDisplayName.ts
+++ b/src/lib/formatters/roomDisplayName.ts
@@ -15,27 +15,21 @@ export function roomTypeDisplayLabel(type: string | undefined | null): string {
 /** Bed spec line including optional modifiers (same rules as quantity cards). */
 export function bedSpecificationLine(room: {
   bed_specifications?: string[] | null;
-  bed_modifiers?: string[] | null;
 }): string | null {
   const specs = room?.bed_specifications;
   if (!Array.isArray(specs) || specs.length === 0) return null;
   const base = specs.filter(Boolean).join(", ");
   if (!base) return null;
-  const mods = room?.bed_modifiers;
-  if (Array.isArray(mods) && mods.length > 0) {
-    return `${base} (${mods.join(", ")})`;
-  }
   return base;
 }
 
 /**
  * Stable bucket for inventory grouping (matches {@link roomTypeAndBedTitle}):
- * prefer `bed_specifications` (+ modifiers), else fall back to `description`.
+ * prefer `bed_specifications`, else fall back to `description`.
  */
 export function roomInventoryGroupKey(room: {
   description?: string | null;
   bed_specifications?: string[] | null;
-  bed_modifiers?: string[] | null;
 }): string {
   const bedLine = bedSpecificationLine(room);
   if (bedLine) return `spec:${bedLine}`;
@@ -50,7 +44,6 @@ export function roomTypeAndBedTitle(room: {
   type?: string | null;
   description?: string | null;
   bed_specifications?: string[] | null;
-  bed_modifiers?: string[] | null;
 }): string {
   const typeLabel = roomTypeDisplayLabel(room?.type);
   const bed = bedSpecificationLine(room);
@@ -68,7 +61,6 @@ export function assignedRoomBillingTitle(room: {
   type?: string | null;
   description?: string | null;
   bed_specifications?: string[] | null;
-  bed_modifiers?: string[] | null;
 }): string {
   const inner = roomTypeAndBedTitle(room);
   const name = (room.name ?? "").trim() || "Room";

--- a/src/pages/Booking/RoomCard.tsx
+++ b/src/pages/Booking/RoomCard.tsx
@@ -15,7 +15,6 @@ interface RoomCardProps {
   includes: string;
   price: string | number;
   bed_specifications?: string[];
-  bed_modifiers?: string[];
   selected?: boolean;
   onSelectRoom: (id: number) => void;
   /** Optional list of amenity names for pill tags (e.g. ["WiFi", "AC", "Slippers"]) */
@@ -41,7 +40,6 @@ export const RoomCard: React.FC<RoomCardProps> = ({
   includes,
   price,
   bed_specifications,
-  bed_modifiers,
   selected = false,
   onSelectRoom,
   amenityPills,
@@ -277,9 +275,6 @@ export const RoomCard: React.FC<RoomCardProps> = ({
             Beds:{" "}
             <span className="font-semibold">
               {bed_specifications.join(", ")}
-              {bed_modifiers &&
-                bed_modifiers.length > 0 &&
-                ` (${bed_modifiers.join(", ")})`}
             </span>
           </p>
         )}

--- a/src/pages/Home/RoomCard.tsx
+++ b/src/pages/Home/RoomCard.tsx
@@ -203,7 +203,6 @@ function RoomCard() {
                     featured_image={room.featured_image as string | null}
                     gallery={room.gallery as string[]}
                     bed_specifications={room.bed_specifications as string[]}
-                    bed_modifiers={room.bed_modifiers as string[]}
                     onClick={() =>
                       navigate(`/rooms/${room.id}`, {
                         state: { room },

--- a/src/pages/SinglePage.tsx
+++ b/src/pages/SinglePage.tsx
@@ -40,7 +40,6 @@ interface ListingItem {
   featured_image?: string | null;
   gallery?: string[];
   bed_specifications?: string[];
-  bed_modifiers?: string[];
 }
 
 function extractList<T>(response: { data?: T[] } | T[] | undefined): T[] {
@@ -369,9 +368,6 @@ const SinglePage = () => {
                       selectedItem.bed_specifications.length > 0 && (
                         <div className="rounded-full bg-gray-100 px-3 py-1 font-medium">
                           Beds: {selectedItem.bed_specifications.join(", ")}
-                          {selectedItem.bed_modifiers &&
-                            selectedItem.bed_modifiers.length > 0 &&
-                            ` (${selectedItem.bed_modifiers.join(", ")})`}
                         </div>
                       )}
                     {isVenuePage &&
@@ -465,7 +461,6 @@ const SinglePage = () => {
                     featured_image={item.featured_image}
                     gallery={item.gallery}
                     bed_specifications={item.bed_specifications}
-                    bed_modifiers={item.bed_modifiers}
                     onClick={() => handleCardClick(item.id, item)}
                   />
                 ))}


### PR DESCRIPTION
This pull request removes all usage and references to the `bed_modifiers` property from the codebase, simplifying the data model and UI for room and bed specifications. All logic, props, and UI elements that previously handled or displayed `bed_modifiers` have been cleaned up for consistency.

**Removal of `bed_modifiers` from components and props:**

* Removed the `bed_modifiers` prop from the `CardItem` and `RoomCard` components, as well as from their corresponding prop interfaces and usages throughout the codebase. [[1]](diffhunk://#diff-654ca9a95337f1f92ab6293233f849c3b840b449ca331caa32d38972235fa6aaL21) [[2]](diffhunk://#diff-654ca9a95337f1f92ab6293233f849c3b840b449ca331caa32d38972235fa6aaL35) [[3]](diffhunk://#diff-ba5e5193c10649f94329b57ce597245c88d2cd572f46c7da4f31ae880e7920ccL18) [[4]](diffhunk://#diff-ba5e5193c10649f94329b57ce597245c88d2cd572f46c7da4f31ae880e7920ccL44) [[5]](diffhunk://#diff-8627ded7ff8b3041af1a3cd04e1328efb2e7e33641f05dcdf1e5167919513f51L206) [[6]](diffhunk://#diff-8ee39a1c02bed8030ca53593b9033e7ea621d09068a133d6187c485475da9ec2L43) [[7]](diffhunk://#diff-8ee39a1c02bed8030ca53593b9033e7ea621d09068a133d6187c485475da9ec2L468)

**UI and display logic cleanup:**

* Removed all UI logic and rendering that displayed `bed_modifiers` alongside bed specifications in `CardItem`, `RoomCard`, and `SinglePage` components. [[1]](diffhunk://#diff-654ca9a95337f1f92ab6293233f849c3b840b449ca331caa32d38972235fa6aaL134-L136) [[2]](diffhunk://#diff-654ca9a95337f1f92ab6293233f849c3b840b449ca331caa32d38972235fa6aaL205-L207) [[3]](diffhunk://#diff-ba5e5193c10649f94329b57ce597245c88d2cd572f46c7da4f31ae880e7920ccL280-L282) [[4]](diffhunk://#diff-8ee39a1c02bed8030ca53593b9033e7ea621d09068a133d6187c485475da9ec2L372-L374)

**Formatter and utility function updates:**

* Updated formatter functions in `roomDisplayName.ts` to remove support for `bed_modifiers`, including the `bedSpecificationLine`, `roomInventoryGroupKey`, `roomTypeAndBedTitle`, and `assignedRoomBillingTitle` functions. [[1]](diffhunk://#diff-63d9bf633f66e447cca2e64279e151063720fc95c3e7972371047abb2a352383L18-L38) [[2]](diffhunk://#diff-63d9bf633f66e447cca2e64279e151063720fc95c3e7972371047abb2a352383L53) [[3]](diffhunk://#diff-63d9bf633f66e447cca2e64279e151063720fc95c3e7972371047abb2a352383L71)

Overall, this change streamlines the handling of bed information by relying solely on `bed_specifications`.…omponents for cleaner code