### PR TITLE
fix: handle HTML responses in reviews API parsing

### DIFF
--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -23,6 +23,7 @@ export const endpoints = {
   galleries: "/galleries",
   blogPosts: "/blog-posts",
   blogPostBySlug: (slug: string) => `/blog-posts/${encodeURIComponent(slug)}`,
+  reviews: "/reviews",
   maintenanceMode: "/maintenance-mode",
   paymentSettings: "/payment-settings",
 } as const;

--- a/src/pages/Testimonial/ReviewSection.tsx
+++ b/src/pages/Testimonial/ReviewSection.tsx
@@ -59,7 +59,7 @@ function normalizeReview(item: unknown): Review {
 function extractReviews(response: ReviewApiResponse): Review[] {
   if (Array.isArray(response)) return response.map(normalizeReview);
 
-  if (response && "reviews" in response && Array.isArray(response.reviews)) {
+  if (response && typeof response === "object" && "reviews" in response && Array.isArray(response.reviews)) {
     return response.reviews.map(normalizeReview);
   }
 


### PR DESCRIPTION
- Add typeof check before using 'in' operator to prevent crash when API returns HTML
- Add missing /reviews endpoint definition in endpoints.ts
- Fixes: TypeError Cannot use 'in' operator to search for 'reviews' in HTML