### PR TITLE
refactor(Messenger): update Facebook Messenger integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,9 @@ VITE_API_KEY=your_api_key_here
 # Send browser error reports to POST /api/client-errors (requires SLACK_ERROR_ALERTS_ENABLED on API). Off in dev unless true.
 # VITE_ERROR_REPORTING=true
 
-# Facebook Messenger URL for billing-statement “Open Messenger” (optional; defaults in booking.constants).
+# Facebook Messenger page ID for billing-statement “Open Messenger” (preferred).
+# VITE_MESSENGER_PAGE_ID=61557457680496
+# Optional full URL override (kept for backward compatibility):
 # VITE_MESSENGER_URL=https://m.me/your-page-id
 
 # Production host(s) where search engines may index (comma-separated). All other domains get noindex.

--- a/src/lib/constants/booking.constants.ts
+++ b/src/lib/constants/booking.constants.ts
@@ -1,12 +1,24 @@
 import { easeInOut } from "framer-motion";
 import type { FormData, RoomTypeFilter, VenueEventType } from "@/types/booking.types";
 
-/** Facebook Messenger deep link for down-payment instructions (override with VITE_MESSENGER_URL). */
-const envMessenger = import.meta.env.VITE_MESSENGER_URL as string | undefined;
+/** Facebook Messenger page ID (preferred), with URL override fallback for backward compatibility. */
+const envMessengerPageId = import.meta.env.VITE_MESSENGER_PAGE_ID as
+  | string
+  | undefined;
+const envMessengerUrl = import.meta.env.VITE_MESSENGER_URL as
+  | string
+  | undefined;
+const DEFAULT_MESSENGER_PAGE_ID = "61557457680496";
+
+export const MESSENGER_PAGE_ID =
+  typeof envMessengerPageId === "string" && envMessengerPageId.trim() !== ""
+    ? envMessengerPageId.trim()
+    : DEFAULT_MESSENGER_PAGE_ID;
+
 export const MESSENGER_CHAT_URL =
-  typeof envMessenger === "string" && envMessenger.trim() !== ""
-    ? envMessenger.trim()
-    : "https://m.me/61557457680496";
+  typeof envMessengerUrl === "string" && envMessengerUrl.trim() !== ""
+    ? envMessengerUrl.trim()
+    : `https://m.me/${MESSENGER_PAGE_ID}`;
 
 /** Default: all room types visible until the guest narrows the list. */
 export const DEFAULT_ROOM_TYPE_FILTERS: RoomTypeFilter[] = [

--- a/src/pages/Booking/Steps/Step5.tsx
+++ b/src/pages/Booking/Steps/Step5.tsx
@@ -470,7 +470,26 @@ function buildMessengerChatUrl(baseUrl: string, message: string): string {
 
   try {
     const parsed = new URL(safeBaseUrl);
-    // Keep configured deep links (ex: m.me) untouched so mobile clients can open Messenger app directly.
+    const host = parsed.hostname.replace(/^www\./, "").toLowerCase();
+    let pageTarget = "";
+
+    if (host === "m.me") {
+      pageTarget = parsed.pathname.replace(/^\/+/, "");
+    } else if (host === "facebook.com" || host === "fb.com") {
+      const path = parsed.pathname.replace(/^\/+/, "");
+      const matched = /^messages\/t\/([^/?#]+)/i.exec(path);
+      if (matched?.[1]) pageTarget = matched[1];
+    }
+
+    if (pageTarget) {
+      // Prefer facebook.com/messages for browser reliability, while app handoff is handled separately.
+      const browserUrl = new URL(
+        `https://www.facebook.com/messages/t/${encodeURIComponent(pageTarget)}`,
+      );
+      browserUrl.searchParams.set("text", message);
+      return browserUrl.toString();
+    }
+
     parsed.searchParams.set("text", message);
     return parsed.toString();
   } catch {
@@ -861,7 +880,7 @@ export function Step5(props: Props) {
     "Thank you!",
   ];
   const messengerPrefilledMessage = messengerMessageLines.join("\n");
-  const messengerChatUrlWithMessage = buildMessengerChatUrl(
+  const messengerBrowserUrlWithMessage = buildMessengerChatUrl(
     MESSENGER_CHAT_URL,
     messengerPrefilledMessage,
   );
@@ -875,7 +894,7 @@ export function Step5(props: Props) {
     const fallbackTimer = window.setTimeout(() => {
       fallbackTriggered = true;
       window.open(
-        messengerChatUrlWithMessage || MESSENGER_CHAT_URL,
+        messengerBrowserUrlWithMessage || MESSENGER_CHAT_URL,
         "_blank",
         "noopener,noreferrer",
       );
@@ -1360,7 +1379,7 @@ export function Step5(props: Props) {
                       {unpaidCancellationDayLabel} if not settled.
                     </p>
                     <a
-                      href={messengerChatUrlWithMessage || MESSENGER_CHAT_URL}
+                      href={messengerBrowserUrlWithMessage || MESSENGER_CHAT_URL}
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={handleOpenMessenger}
@@ -1368,6 +1387,14 @@ export function Step5(props: Props) {
                     >
                       <MessengerGlyph className="size-5 shrink-0" aria-hidden />
                       <span>Open Messenger</span>
+                    </a>
+                    <a
+                      href={messengerBrowserUrlWithMessage || MESSENGER_CHAT_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-2 inline-flex items-center rounded-lg border border-sand-dark/35 bg-white px-3 py-2 text-xs font-semibold text-ink shadow-sm hover:bg-sage-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sea/40"
+                    >
+                      Open in Browser
                     </a>
                   </div>
                 )}


### PR DESCRIPTION
- Replaced the deep link for Messenger with a preferred page ID and added a URL override for backward compatibility.
- Enhanced the logic for building Messenger chat URLs to prioritize browser reliability and added a new option to open Messenger in the browser.
- Updated the Step5 component to reflect these changes, ensuring a smoother user experience when accessing Messenger.